### PR TITLE
feat: add regex search support for provider filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ The Graph View helps you understand provider relationships in your application:
 
 1. **Switch to Graph Tab**: Click the "Graph" tab in the toolbar
 2. **Interact with Your App**: As you use your app, the graph will populate with providers
-3. **View Type Statistics**: 
+3. **View Type Statistics**:
    - The toolbar shows a count for each provider type with its corresponding color
    - Quickly see the distribution of provider types in your app (e.g., "Notifier: 3", "Future: 2", "Stream: 1")
    - Each type chip uses the same color as its nodes in the graph
@@ -542,6 +542,25 @@ The Graph View helps you understand provider relationships in your application:
 7. **Clear Network**: Click the clear button to start fresh
 
 **Note**: The graph shows *inferred* dependencies based on temporal proximity of updates, not the actual Riverpod dependency graph (which is not accessible through the public API).
+
+#### Search Modes
+
+The search box supports two modes:
+
+**Simple Search (Default)**
+- Case-insensitive substring matching
+- Quick and easy filtering
+- Example: typing "counter" will match "counterProvider", "myCounterState", etc.
+
+**Regex Search**
+- Advanced pattern matching using regular expressions
+- Click the search mode icon (text fields ⇄ code icon) to switch modes
+- Supports full regex syntax for complex patterns
+- Real-time validation with error messages for invalid patterns
+- Examples:
+  - `^counter.*Provider$` - Matches providers starting with "counter" and ending with "Provider"
+  - `(user|auth).*State` - Matches providers containing "user" or "auth" followed by "State"
+  - `\d+Provider` - Matches providers with numbers followed by "Provider"
 
 ### Tips for Using the Extension
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -481,6 +481,25 @@ RiverpodDevToolsObserver(
 
 **注意**：圖表顯示的是基於更新時序推斷的依賴關係，而非實際的 Riverpod 依賴圖（無法透過公開 API 存取）。
 
+#### 搜尋模式
+
+搜尋框支援兩種模式：
+
+**簡單搜尋（預設）**
+- 不區分大小寫的子字串匹配
+- 快速且簡單的篩選
+- 範例：輸入 "counter" 會匹配 "counterProvider"、"myCounterState" 等
+
+**正規表達式搜尋**
+- 使用正規表達式進行進階模式匹配
+- 點擊搜尋模式圖示（文字欄位 ⇄ 程式碼圖示）來切換模式
+- 支援完整的 regex 語法處理複雜模式
+- 即時驗證，無效模式會顯示錯誤訊息
+- 範例：
+  - `^counter.*Provider$` - 匹配以 "counter" 開頭且以 "Provider" 結尾的 provider
+  - `(user|auth).*State` - 匹配包含 "user" 或 "auth" 後接 "State" 的 provider
+  - `\d+Provider` - 匹配包含數字後接 "Provider" 的 provider
+
 ### 使用技巧
 
 - **找出狀態 Bug**：查看調用鏈了解狀態為何意外變化


### PR DESCRIPTION
## Summary

Implements **Issue #11** - Enhance Search with Regex Support

This PR adds advanced regex search capabilities to the DevTools extension's provider filtering, allowing users to use powerful regular expression patterns to filter providers.

## Changes

### Core Features
- ✅ **Search Mode Toggle**: Added PopupMenuButton to switch between Simple and Regex search modes
- ✅ **Regex Compilation**: Real-time regex pattern compilation with validation
- ✅ **Error Feedback**: Display error messages for invalid regex patterns with icon and description
- ✅ **Full Regex Support**: Support complete regex syntax for complex filtering patterns

### Implementation Details
- Added `SearchMode` enum with `simple` and `regex` values
- Added state variables: `_searchMode`, `_searchRegex`, `_regexError`
- Modified `_searchSuggestions` getter to handle both search modes
- Enhanced TextField `onChanged` handler with regex compilation and error handling
- Wrapped search controls in Column to display error messages below search box
- Added PopupMenuButton with icons (text_fields ⇄ code) for mode switching

### Documentation
- Added "Search Modes" section to both README.md and README.zh-TW.md
- Provided regex examples:
  - `^counter.*Provider$` - Match providers starting with "counter" and ending with "Provider"
  - `(user|auth).*State` - Match providers containing "user" or "auth" followed by "State"
  - `\d+Provider` - Match providers with numbers followed by "Provider"

## Testing

- ✅ Code compiles without errors
- ✅ DevTools extension builds successfully
- ✅ Flutter analyze passes (only pre-existing warnings in state_detail_panel.dart)

## Screenshots

The UI includes:
- Search mode toggle button (text fields icon for simple, code icon for regex)
- Real-time error feedback for invalid regex patterns
- Popup menu for easy mode switching

## Related Issues

Closes #11

## Test Plan

**Manual Testing:**
1. Open DevTools extension
2. Try simple search (default mode) - verify case-insensitive substring matching works
3. Click mode toggle button to switch to regex mode
4. Try valid regex patterns - verify they work correctly
5. Try invalid regex pattern - verify error message appears
6. Switch back to simple mode - verify simple search still works